### PR TITLE
Add agentic coding helpers for Neovim and Fish

### DIFF
--- a/fish/functions/claude-diff.fish
+++ b/fish/functions/claude-diff.fish
@@ -1,0 +1,25 @@
+# Copy git diff to clipboard for sharing with Claude
+# Usage: claude-diff [git diff args]
+# Examples:
+#   claude-diff              # staged + unstaged changes
+#   claude-diff --staged     # only staged changes
+#   claude-diff HEAD~3       # last 3 commits
+function claude-diff
+    set -l diff_output
+
+    if test (count $argv) -eq 0
+        # Default: show both staged and unstaged
+        set diff_output (git diff HEAD 2>/dev/null)
+    else
+        set diff_output (git diff $argv 2>/dev/null)
+    end
+
+    if test -z "$diff_output"
+        echo "No changes to copy"
+        return 1
+    end
+
+    echo $diff_output | pbcopy
+    set -l lines (echo $diff_output | wc -l | string trim)
+    echo "Copied $lines lines of diff to clipboard"
+end

--- a/fish/functions/claude-file.fish
+++ b/fish/functions/claude-file.fish
@@ -1,0 +1,37 @@
+# Copy file contents with path header to clipboard for sharing with Claude
+# Usage: claude-file <file> [file2] [file3] ...
+# Examples:
+#   claude-file src/main.go
+#   claude-file src/main.go src/utils.go
+function claude-file
+    if test (count $argv) -eq 0
+        echo "Usage: claude-file <file> [file2] ..."
+        return 1
+    end
+
+    set -l output ""
+
+    for file in $argv
+        if not test -f $file
+            echo "File not found: $file"
+            return 1
+        end
+
+        # Get git-relative path if in a repo, otherwise use the provided path
+        set -l display_path $file
+        if git rev-parse --git-dir >/dev/null 2>&1
+            set -l git_root (git rev-parse --show-toplevel)
+            set -l abs_path (realpath $file)
+            set display_path (string replace "$git_root/" "" $abs_path)
+        end
+
+        # Add file with header
+        if test -n "$output"
+            set output "$output\n\n"
+        end
+        set output "$output// $display_path\n"(cat $file)
+    end
+
+    echo -e $output | pbcopy
+    echo "Copied "(count $argv)" file(s) to clipboard"
+end


### PR DESCRIPTION
## Summary

- Add Neovim keymaps for quickly sharing code context with Claude
- Add Fish helper functions for copying diffs and files to clipboard
- Add Claude terminal integration with optional yolo mode

## Neovim Keymaps

| Keymap | Description |
|--------|-------------|
| `<leader>yl` | Copy `filepath:line` to clipboard |
| `<leader>yd` | Copy diagnostic message on current line |
| `<leader>yc` | (visual) Copy selection with `// path:start-end` header |
| `<leader>tc` | Open Claude in vsplit terminal |
| `<leader>tC` | Open Claude in horizontal split terminal |
| `<leader>Tc` | Open Claude in vsplit (yolo mode - skip permissions) |
| `<leader>TC` | Open Claude in split (yolo mode - skip permissions) |

## Fish Functions

| Function | Description |
|----------|-------------|
| `claude-diff` | Copy git diff to clipboard |
| `claude-file <file>` | Copy file(s) with path header to clipboard |

## Test plan

- [ ] Verify `<leader>yl` copies `path:line` format
- [ ] Verify `<leader>yd` copies diagnostic messages
- [ ] Verify `<leader>yc` in visual mode copies with context header
- [ ] Verify `<leader>tc` and `<leader>Tc` open Claude terminals
- [ ] Verify `claude-diff` and `claude-file` work in fish

🤖 Generated with [Claude Code](https://claude.com/claude-code)